### PR TITLE
Specify bg and fg colors

### DIFF
--- a/protractor.py
+++ b/protractor.py
@@ -115,7 +115,7 @@ class Protractor(QLabel):
         self.setWindowFlags(Qt.WindowStaysOnTopHint)
         self.setAttribute(Qt.WA_TranslucentBackground, True)
         # self.setAttribute(Qt.WA_TransparentForMouseEvents)
-        self.setStyleSheet("QLabel#angle { font-size: 20px; background-color: white; padding: 2px; }")
+        self.setStyleSheet("QLabel#angle { font-size: 20px; background-color: silver; color: black; padding: 2px; }")
         self.setCursor(Qt.OpenHandCursor)
         self.handleC = Handle(self)
         self.handle1 = Handle(self)


### PR DESCRIPTION
The old code was rendering a white background with a user-defined foreground (i.e. text) color.

If the user has a dark theme, that means white background with white text, making the tool unusable.

This commit forces a pair of colors. It would be even beter to reuse the user-chosen colors from the current theme, but this is already good enough.